### PR TITLE
Add multi-channel distribution: PyPI, Homebrew, npm, apt/deb

### DIFF
--- a/.github/workflows/release-kimigas.yml
+++ b/.github/workflows/release-kimigas.yml
@@ -1,0 +1,266 @@
+name: Release (kimigas)
+
+on:
+  push:
+    tags:
+      - "v[0-9]*"
+
+permissions:
+  contents: write
+
+env:
+  KIMIGAS_VERSION: ${{ github.ref_name }}
+
+jobs:
+  build:
+    name: Build binaries (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            os: linux
+            arch: amd64
+          - runner: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
+            os: linux
+            arch: arm64
+          - runner: macos-14
+            target: aarch64-apple-darwin
+            os: darwin
+            arch: arm64
+          - runner: windows-2022
+            target: x86_64-pc-windows-msvc
+            os: windows
+            arch: amd64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install GNU Make (Windows)
+        if: runner.os == 'Windows'
+        run: choco install make -y
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          allow-prereleases: true
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v1
+        with:
+          version: "0.8.5"
+
+      - name: Set up Node.js (web build)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Prepare build environment
+        run: make prepare-build
+
+      - name: Build standalone binary
+        run: make build-bin
+
+      - name: Package binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          TARGET="${{ matrix.target }}"
+          mkdir -p artifacts
+
+          if [[ "${{ matrix.os }}" == "windows" ]]; then
+            BINARY="dist/onefile/kimi.exe"
+            ARCHIVE="artifacts/kimigas-${TAG}-${TARGET}.zip"
+            cd dist/onefile && zip -9 "../../${ARCHIVE}" kimi.exe && cd ../..
+          else
+            BINARY="dist/onefile/kimi"
+            ARCHIVE="artifacts/kimigas-${TAG}-${TARGET}.tar.gz"
+            tar -czf "${ARCHIVE}" -C dist/onefile kimi
+          fi
+
+          echo "Built: ${ARCHIVE}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kimigas-${{ matrix.target }}
+          path: artifacts/*
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./downloads
+          merge-multiple: true
+
+      - name: Generate SHA256 checksums
+        run: |
+          cd downloads
+          for f in *.tar.gz *.zip; do
+            [ -f "$f" ] && sha256sum "$f" > "$f.sha256"
+          done
+          ls -la
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: kimigas ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |
+            downloads/*.tar.gz
+            downloads/*.zip
+            downloads/*.sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          allow-prereleases: true
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v1
+        with:
+          version: "0.8.5"
+
+      - name: Set up Node.js (web build)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build Python package
+        run: |
+          uv build --package kimi-cli
+          ls -la dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: dist
+
+  publish-npm:
+    name: Publish to npm
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish npm package
+        working-directory: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          npm version "$VERSION" --no-git-tag-version
+          npm publish --access public
+
+  publish-deb:
+    name: Build and attach .deb packages
+    needs: build
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            arch: amd64
+          - target: aarch64-unknown-linux-gnu
+            arch: arm64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download Linux binary
+        uses: actions/download-artifact@v4
+        with:
+          name: kimigas-${{ matrix.target }}
+          path: ./downloads
+
+      - name: Build .deb package
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          ARCH="${{ matrix.arch }}"
+
+          # Extract binary
+          mkdir -p extract
+          tar -xzf downloads/kimigas-${VERSION}-${{ matrix.target }}.tar.gz -C extract/
+
+          # Build deb structure
+          PKG="kimigas_${VERSION}_${ARCH}"
+          mkdir -p "${PKG}/DEBIAN"
+          mkdir -p "${PKG}/usr/bin"
+          mkdir -p "${PKG}/usr/share/doc/kimigas"
+
+          cp extract/kimi "${PKG}/usr/bin/kimigas"
+          chmod 755 "${PKG}/usr/bin/kimigas"
+
+          # Also symlink as 'kimi' for upstream compatibility
+          ln -s kimigas "${PKG}/usr/bin/kimi"
+
+          cat > "${PKG}/DEBIAN/control" << CTRL
+          Package: kimigas
+          Version: ${VERSION}
+          Architecture: ${ARCH}
+          Maintainer: Gas Town <gastown@villamarket.ai>
+          Description: Kimi Code CLI for Gas Town
+           kimigas is a Gas Town fork of kimi-cli by MoonshotAI. An AI agent
+           that runs in the terminal for software development tasks and
+           multi-agent orchestration.
+          Homepage: https://github.com/gastown-publish/kimigas
+          Section: devel
+          Priority: optional
+          CTRL
+          # Remove leading spaces from heredoc
+          sed -i 's/^          //' "${PKG}/DEBIAN/control"
+
+          cp README.md "${PKG}/usr/share/doc/kimigas/"
+
+          dpkg-deb --build --root-owner-group "${PKG}"
+          mv "${PKG}.deb" "kimigas_${VERSION}_${ARCH}.deb"
+
+          echo "Built: kimigas_${VERSION}_${ARCH}.deb"
+
+      - name: Upload .deb to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: "*.deb"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,84 @@
+name: Update Homebrew Formula
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-tap:
+    name: Update Homebrew tap
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tap repo
+        uses: actions/checkout@v4
+        with:
+          repository: gastown-publish/homebrew-tap
+          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+          path: tap
+
+      - name: Update formula
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          FORMULA="tap/Formula/kimigas.rb"
+
+          # Download and compute checksums
+          for target in aarch64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu; do
+            URL="https://github.com/gastown-publish/kimigas/releases/download/v${VERSION}/kimigas-${VERSION}-${target}.tar.gz"
+            SHA=$(curl -fsSL "${URL}" | sha256sum | cut -d' ' -f1)
+            echo "${target}: ${SHA}"
+
+            case "$target" in
+              aarch64-apple-darwin)   DARWIN_ARM64_SHA="$SHA" ;;
+              x86_64-unknown-linux-gnu) LINUX_AMD64_SHA="$SHA" ;;
+              aarch64-unknown-linux-gnu) LINUX_ARM64_SHA="$SHA" ;;
+            esac
+          done
+
+          cat > "$FORMULA" << RUBY
+          class Kimigas < Formula
+            desc "Kimi Code CLI for Gas Town - AI agent for terminal-based development"
+            homepage "https://github.com/gastown-publish/kimigas"
+            license "Apache-2.0"
+            version "${VERSION}"
+
+            on_macos do
+              on_arm do
+                url "https://github.com/gastown-publish/kimigas/releases/download/v${VERSION}/kimigas-${VERSION}-aarch64-apple-darwin.tar.gz"
+                sha256 "${DARWIN_ARM64_SHA}"
+              end
+            end
+
+            on_linux do
+              on_intel do
+                url "https://github.com/gastown-publish/kimigas/releases/download/v${VERSION}/kimigas-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+                sha256 "${LINUX_AMD64_SHA}"
+              end
+
+              on_arm do
+                url "https://github.com/gastown-publish/kimigas/releases/download/v${VERSION}/kimigas-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
+                sha256 "${LINUX_ARM64_SHA}"
+              end
+            end
+
+            def install
+              bin.install "kimi" => "kimigas"
+              bin.install_symlink "kimigas" => "kimi"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/kimigas --version 2>&1")
+            end
+          end
+          RUBY
+          # Remove leading whitespace from heredoc
+          sed -i 's/^          //' "$FORMULA"
+
+      - name: Commit and push
+        working-directory: tap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/kimigas.rb
+          git commit -m "Update kimigas to ${GITHUB_REF_NAME#v}"
+          git push

--- a/README.md
+++ b/README.md
@@ -8,21 +8,33 @@
 
 Kimi Code CLI is an AI agent that runs in the terminal, helping you complete software development tasks and terminal operations. It can read and edit code, execute shell commands, search and fetch web pages, and autonomously plan and adjust actions during execution.
 
-## Getting Started
+## Install
 
-> **This is the [Gas Town fork](https://github.com/gastown-publish/kimigas)** with tmux compatibility patches, message queuing, and multi-agent orchestration support. Install from this repo (not PyPI) to get these features:
->
-> ```sh
-> # Option 1: uv (recommended)
-> uv tool install git+https://github.com/gastown-publish/kimigas.git
->
-> # Option 2: pip
-> pip install git+https://github.com/gastown-publish/kimigas.git
-> ```
->
-> See the [Gas Town integration guide](docs/en/guides/gastown.md) for setup details.
+> **This is the [Gas Town fork](https://github.com/gastown-publish/kimigas)** with tmux compatibility patches, message queuing, and multi-agent orchestration support.
 
-For upstream documentation, see [Getting Started](https://moonshotai.github.io/kimi-cli/en/guides/getting-started.html).
+```sh
+# Quick install (Linux/macOS)
+curl -fsSL https://raw.githubusercontent.com/gastown-publish/kimigas/main/install.sh | bash
+
+# Homebrew (macOS/Linux)
+brew install gastown-publish/tap/kimigas
+
+# pip / uv (all platforms)
+pip install kimigas
+uv tool install kimigas
+
+# npm (all platforms)
+npm install -g kimigas
+
+# apt (Debian/Ubuntu) — download .deb from GitHub releases
+curl -LO "https://github.com/gastown-publish/kimigas/releases/latest/download/kimigas_$(curl -s https://api.github.com/repos/gastown-publish/kimigas/releases/latest | grep tag_name | grep -o '[0-9.]*')_amd64.deb"
+sudo dpkg -i kimigas_*.deb
+
+# From source
+uv tool install git+https://github.com/gastown-publish/kimigas.git
+```
+
+See the [Gas Town integration guide](docs/en/guides/gastown.md) for setup details. For upstream documentation, see [Getting Started](https://moonshotai.github.io/kimi-cli/en/guides/getting-started.html).
 
 ## Key Features
 

--- a/homebrew/kimigas.rb
+++ b/homebrew/kimigas.rb
@@ -1,0 +1,33 @@
+class Kimigas < Formula
+  desc "Kimi Code CLI for Gas Town - AI agent for terminal-based development"
+  homepage "https://github.com/gastown-publish/kimigas"
+  license "Apache-2.0"
+  version "0.1.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/gastown-publish/kimigas/releases/download/v#{version}/kimigas-#{version}-aarch64-apple-darwin.tar.gz"
+      # sha256 will be updated by release workflow
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/gastown-publish/kimigas/releases/download/v#{version}/kimigas-#{version}-x86_64-unknown-linux-gnu.tar.gz"
+    end
+
+    on_arm do
+      url "https://github.com/gastown-publish/kimigas/releases/download/v#{version}/kimigas-#{version}-aarch64-unknown-linux-gnu.tar.gz"
+    end
+  end
+
+  def install
+    bin.install "kimi" => "kimigas"
+    # Also install as 'kimi' for upstream compatibility
+    bin.install_symlink "kimigas" => "kimi"
+  end
+
+  test do
+    assert_match "kimigas", shell_output("#{bin}/kimigas --version 2>&1", 0)
+  end
+end

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# kimigas universal installer
+# Usage: curl -fsSL https://raw.githubusercontent.com/gastown-publish/kimigas/main/install.sh | bash
+set -euo pipefail
+
+REPO="gastown-publish/kimigas"
+BINARY_NAME="kimigas"
+INSTALL_DIR="${KIMIGAS_INSTALL_DIR:-$HOME/.local/bin}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info() { echo -e "${GREEN}==>${NC} $*"; }
+warn() { echo -e "${YELLOW}==>${NC} $*"; }
+error() { echo -e "${RED}Error:${NC} $*" >&2; exit 1; }
+
+# Detect platform
+detect_platform() {
+  local os arch
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+
+  case "$os" in
+    linux)  OS="linux" ;;
+    darwin) OS="darwin" ;;
+    *)      error "Unsupported OS: $os" ;;
+  esac
+
+  case "$arch" in
+    x86_64|amd64)  ARCH="x86_64"; TARGET="x86_64-unknown-linux-gnu" ;;
+    aarch64|arm64) ARCH="aarch64"; TARGET="aarch64-unknown-linux-gnu" ;;
+    *)             error "Unsupported architecture: $arch" ;;
+  esac
+
+  if [[ "$OS" == "darwin" ]]; then
+    TARGET="aarch64-apple-darwin"
+  fi
+}
+
+# Get latest version from GitHub
+get_latest_version() {
+  if command -v gh &>/dev/null; then
+    VERSION=$(gh api "repos/${REPO}/releases/latest" --jq '.tag_name' 2>/dev/null | tr -d 'v')
+  elif command -v curl &>/dev/null; then
+    VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep -o '"tag_name": *"[^"]*"' | head -1 | grep -o 'v[0-9.]*' | tr -d 'v')
+  else
+    error "Need curl or gh CLI to detect latest version"
+  fi
+
+  if [[ -z "${VERSION:-}" ]]; then
+    error "Could not determine latest version. Check https://github.com/${REPO}/releases"
+  fi
+}
+
+install_binary() {
+  local url="https://github.com/${REPO}/releases/download/v${VERSION}/kimigas-${VERSION}-${TARGET}.tar.gz"
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+
+  info "Downloading kimigas v${VERSION} for ${TARGET}..."
+  curl -fsSL "$url" -o "${tmp_dir}/kimigas.tar.gz" || error "Download failed. Check if release exists: $url"
+
+  info "Installing to ${INSTALL_DIR}..."
+  mkdir -p "$INSTALL_DIR"
+  tar -xzf "${tmp_dir}/kimigas.tar.gz" -C "${tmp_dir}/"
+  mv "${tmp_dir}/kimi" "${INSTALL_DIR}/${BINARY_NAME}"
+  chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+
+  # Create kimi symlink for upstream compatibility
+  ln -sf "${INSTALL_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/kimi"
+
+  rm -rf "$tmp_dir"
+}
+
+check_path() {
+  if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
+    warn "${INSTALL_DIR} is not in your PATH"
+    echo ""
+    echo "Add to your shell profile:"
+    echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    echo ""
+  fi
+}
+
+main() {
+  info "kimigas installer"
+  detect_platform
+  get_latest_version
+  install_binary
+  check_path
+  info "kimigas v${VERSION} installed successfully!"
+  echo ""
+  echo "  kimigas --version    # Verify installation"
+  echo "  kimigas --help       # Get started"
+  echo ""
+}
+
+main

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,40 @@
+# kimigas
+
+Kimi Code CLI for [Gas Town](https://github.com/steveyegge/gastown) — an AI agent for terminal-based software development and multi-agent orchestration.
+
+This is the Gas Town fork of [kimi-cli](https://github.com/MoonshotAI/kimi-cli) by MoonshotAI, with tmux compatibility, message queuing, and multi-agent support.
+
+## Install
+
+```sh
+npm install -g kimigas
+```
+
+## Other installation methods
+
+```sh
+# Homebrew
+brew install gastown-publish/tap/kimigas
+
+# pip
+pip install kimigas
+
+# apt (Debian/Ubuntu)
+# Download .deb from GitHub releases
+curl -LO https://github.com/gastown-publish/kimigas/releases/latest/download/kimigas_VERSION_amd64.deb
+sudo dpkg -i kimigas_*.deb
+```
+
+## Usage
+
+```sh
+kimigas              # Interactive mode
+kimigas -p "task"    # One-shot mode
+kimigas --yolo       # Auto-approve all actions (for Gas Town agents)
+```
+
+## Links
+
+- [GitHub](https://github.com/gastown-publish/kimigas)
+- [Gas Town](https://github.com/steveyegge/gastown)
+- [Upstream kimi-cli](https://github.com/MoonshotAI/kimi-cli)

--- a/npm/bin/kimigas
+++ b/npm/bin/kimigas
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+"use strict";
+
+const { execFileSync } = require("child_process");
+const path = require("path");
+const os = require("os");
+const fs = require("fs");
+
+const binDir = __dirname;
+const isWindows = os.platform() === "win32";
+const binaryName = isWindows ? "kimigas.exe" : "kimigas";
+const binaryPath = path.join(binDir, binaryName);
+
+if (!fs.existsSync(binaryPath)) {
+  console.error("kimigas binary not found. Run: npm rebuild kimigas");
+  process.exit(1);
+}
+
+try {
+  const result = execFileSync(binaryPath, process.argv.slice(2), {
+    stdio: "inherit",
+    env: process.env,
+  });
+} catch (err) {
+  process.exit(err.status || 1);
+}

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+"use strict";
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+const os = require("os");
+
+const VERSION = require("./package.json").version;
+const REPO = "gastown-publish/kimigas";
+
+const PLATFORM_MAP = {
+  darwin: { arm64: "aarch64-apple-darwin" },
+  linux: {
+    x64: "x86_64-unknown-linux-gnu",
+    arm64: "aarch64-unknown-linux-gnu",
+  },
+  win32: { x64: "x86_64-pc-windows-msvc" },
+};
+
+function getTarget() {
+  const platform = os.platform();
+  const arch = os.arch();
+  const targets = PLATFORM_MAP[platform];
+  if (!targets || !targets[arch]) {
+    console.error(
+      `Unsupported platform: ${platform}-${arch}. Install via pip instead: pip install kimigas`
+    );
+    process.exit(1);
+  }
+  return targets[arch];
+}
+
+function download(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          return download(res.headers.location).then(resolve, reject);
+        }
+        if (res.statusCode !== 200) {
+          return reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+        }
+        const chunks = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => resolve(Buffer.concat(chunks)));
+        res.on("error", reject);
+      })
+      .on("error", reject);
+  });
+}
+
+async function install() {
+  const target = getTarget();
+  const isWindows = os.platform() === "win32";
+  const ext = isWindows ? "zip" : "tar.gz";
+  const url = `https://github.com/${REPO}/releases/download/v${VERSION}/kimigas-${VERSION}-${target}.${ext}`;
+
+  console.log(`Downloading kimigas v${VERSION} for ${target}...`);
+
+  const binDir = path.join(__dirname, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+
+  try {
+    const data = await download(url);
+    const tmpFile = path.join(os.tmpdir(), `kimigas-download.${ext}`);
+    fs.writeFileSync(tmpFile, data);
+
+    if (isWindows) {
+      execSync(`powershell -Command "Expand-Archive -Path '${tmpFile}' -DestinationPath '${binDir}' -Force"`, { stdio: "inherit" });
+      // Rename kimi.exe to kimigas.exe
+      const src = path.join(binDir, "kimi.exe");
+      const dst = path.join(binDir, "kimigas.exe");
+      if (fs.existsSync(src)) fs.renameSync(src, dst);
+    } else {
+      execSync(`tar -xzf "${tmpFile}" -C "${binDir}"`, { stdio: "inherit" });
+      // Rename kimi to kimigas
+      const src = path.join(binDir, "kimi");
+      const dst = path.join(binDir, "kimigas");
+      if (fs.existsSync(src)) fs.renameSync(src, dst);
+      fs.chmodSync(dst, 0o755);
+    }
+
+    fs.unlinkSync(tmpFile);
+    console.log(`kimigas v${VERSION} installed successfully`);
+  } catch (err) {
+    console.error(`Failed to download binary: ${err.message}`);
+    console.error("Falling back to pip installation...");
+    try {
+      execSync(`pip install kimigas==${VERSION}`, { stdio: "inherit" });
+      // Create a wrapper script
+      const wrapper = isWindows
+        ? `@echo off\npython -m kimi_cli %*`
+        : `#!/bin/sh\nexec python -m kimi_cli "$@"`;
+      const wrapperPath = path.join(binDir, isWindows ? "kimigas.cmd" : "kimigas");
+      fs.writeFileSync(wrapperPath, wrapper);
+      if (!isWindows) fs.chmodSync(wrapperPath, 0o755);
+      console.log("kimigas installed via pip fallback");
+    } catch {
+      console.error("pip fallback also failed. Install manually:");
+      console.error("  pip install kimigas");
+      process.exit(1);
+    }
+  }
+}
+
+install();

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "kimigas",
+  "version": "0.1.0",
+  "description": "Kimi Code CLI for Gas Town — AI agent for terminal-based software development and multi-agent orchestration",
+  "keywords": ["ai", "cli", "agent", "gastown", "kimi", "coding-agent", "terminal"],
+  "homepage": "https://github.com/gastown-publish/kimigas",
+  "bugs": "https://github.com/gastown-publish/kimigas/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gastown-publish/kimigas.git"
+  },
+  "license": "Apache-2.0",
+  "bin": {
+    "kimigas": "bin/kimigas"
+  },
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "os": ["darwin", "linux", "win32"],
+  "cpu": ["x64", "arm64"],
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "bin/",
+    "install.js",
+    "README.md"
+  ]
+}


### PR DESCRIPTION
## Summary

- Release workflow for building binaries (Linux/macOS/Windows) and publishing to PyPI, npm, GitHub Releases
- Homebrew tap at `gastown-publish/homebrew-tap` with auto-update workflow
- npm package with binary downloader and pip fallback
- .deb packages built in CI and attached to GitHub Releases
- Universal install script: `curl -fsSL .../install.sh | bash`
- Updated README with all installation methods

## Install methods after merge + first release

```sh
# Quick install
curl -fsSL https://raw.githubusercontent.com/gastown-publish/kimigas/main/install.sh | bash

# Homebrew
brew install gastown-publish/tap/kimigas

# pip
pip install kimigas

# npm
npm install -g kimigas

# apt/deb
sudo dpkg -i kimigas_VERSION_amd64.deb
```

## Required secrets

Before first release tag, set these in repo settings:
- `PYPI_API_TOKEN` — for PyPI publishing
- `NPM_TOKEN` — for npm publishing
- `TAP_GITHUB_TOKEN` — PAT with repo scope for updating homebrew-tap

## Test plan

- [ ] Merge to main
- [ ] Push tag `v0.1.0` to trigger release workflow
- [ ] Verify GitHub Release created with binaries
- [ ] Verify PyPI publish (after setting PYPI_API_TOKEN)
- [ ] Verify npm publish (after setting NPM_TOKEN)
- [ ] Verify .deb packages attached to release
- [ ] Verify Homebrew formula updated in tap repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)