### PR TITLE
ci: add version check workflow to prevent release version mismatches

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,104 @@
+name: Version Check
+
+on:
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - "packages/**/pyproject.toml"
+      - ".github/workflows/version-check.yml"
+  workflow_dispatch:
+    inputs:
+      expected_version:
+        description: "Expected version to check against (e.g., 1.14.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  version-check:
+    name: Validate Version Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Extract version from pyproject.toml
+        id: extract_version
+        run: |
+          python3 << 'EOF'
+          import tomllib
+          import sys
+          from pathlib import Path
+
+          pyproject_path = Path("pyproject.toml")
+          with pyproject_path.open("rb") as f:
+              data = tomllib.load(f)
+          
+          version = data.get("project", {}).get("version")
+          if not version:
+              print("ERROR: Could not extract version from pyproject.toml", file=sys.stderr)
+              sys.exit(1)
+          
+          print(f"Extracted version: {version}")
+          # Output for GitHub Actions
+          import os
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"version={version}\n")
+          EOF
+
+      - name: Display extracted version
+        run: |
+          echo "Version in pyproject.toml: ${{ steps.extract_version.outputs.version }}"
+
+      - name: Check version against expected (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          EXPECTED_VERSION="${{ github.event.inputs.expected_version }}"
+          ACTUAL_VERSION="${{ steps.extract_version.outputs.version }}"
+          
+          echo "Expected version: $EXPECTED_VERSION"
+          echo "Actual version: $ACTUAL_VERSION"
+          
+          if [ "$EXPECTED_VERSION" != "$ACTUAL_VERSION" ]; then
+            echo "ERROR: Version mismatch!"
+            echo "  Expected: $EXPECTED_VERSION"
+            echo "  Actual:   $ACTUAL_VERSION"
+            echo ""
+            echo "Please update the version in pyproject.toml before releasing."
+            exit 1
+          fi
+          
+          echo "✅ Version check passed: $ACTUAL_VERSION matches expected $EXPECTED_VERSION"
+
+      - name: Validate version format
+        run: |
+          VERSION="${{ steps.extract_version.outputs.version }}"
+          
+          # Validate semver format (x.y.z)
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: Version '$VERSION' does not follow semantic versioning (x.y.z)"
+            exit 1
+          fi
+          
+          echo "✅ Version format is valid: $VERSION"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Version Check Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version in pyproject.toml:** ${{ steps.extract_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+          
+          if [ "${{ job.status }}" == "success" ]; then
+            echo "- **Status:** ✅ PASSED" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- **Status:** ❌ FAILED" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow that validates version consistency in pyproject.toml to prevent release mismatches like Issue #2.

## Problem

Issue #2 reported that the v1.12.0 release binary incorrectly reported version 1.9.0 because the version in pyproject.toml wasn't updated before the release was created.

## Solution

Added `.github/workflows/version-check.yml` that:

1. **Automatic PR checks**: Runs when pyproject.toml is modified in a PR
2. **Manual validation**: Can be triggered via workflow_dispatch with expected version
3. **Version format validation**: Ensures semantic versioning (x.y.z format)
4. **Mismatch detection**: Fails workflow if versions don't match (for manual triggers)
5. **GitHub summary**: Provides detailed status output

## Features

- Extracts version from pyproject.toml using Python's tomllib
- Validates semantic versioning format
- Supports manual version comparison via workflow_dispatch
- Creates GitHub step summary for visibility

## Testing

- [x] Workflow syntax validated
- [x] Version extraction tested locally
- [x] Follows repository's CI workflow patterns

## Related Issues

Fixes #2