### PR TITLE
chore: add missing test dependencies (respx, openai, asyncssh)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "ruff>=0.14.10",
+    "respx>=0.22.0",       # API snapshot testing
+    "openai>=1.0.0",       # Chat provider tests
+    "asyncssh>=2.14.0",    # SSH tests
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

This PR adds three missing test dependencies to enable the full test suite to run.

## Problem

When running the test suite, several test files were being skipped due to missing dependencies:

- **respx**: Required for API snapshot tests in `packages/kosong/tests/api_snapshot_tests/`
- **openai**: Required for chat provider tests in `packages/kosong/tests/test_chat_provider.py`
- **asyncssh**: Required for SSH tests in `packages/kaos/tests/test_ssh_kaos.py`

## Solution

Added the following dependencies to `[dependency-groups] dev` in pyproject.toml:

```toml
[dependency-groups]
dev = [
    # ... existing dependencies ...
    "respx>=0.22.0",       # API snapshot testing
    "openai>=1.0.0",       # Chat provider tests
    "asyncssh>=2.14.0",    # SSH tests
]
```

## Impact

- Enables ~10 additional test files to run
- Improves test coverage for API integrations
- Allows SSH functionality testing

## Post-Merge Steps

After merging this PR, run:
```bash
uv lock  # Update uv.lock with new dependencies
```

## Testing

- [x] Dependencies added to correct section
- [x] Version constraints are reasonable
- [x] Follows existing dependency format