### PR TITLE
Fix: Hardcode version to resolve stale cached version issue (#2)

### DIFF
--- a/src/kimi_cli/constant.py
+++ b/src/kimi_cli/constant.py
@@ -3,5 +3,5 @@ from __future__ import annotations
 import importlib.metadata
 
 NAME = "Kimi Code CLI"
-VERSION = importlib.metadata.version("kimi-cli")
+VERSION = "1.14.0"  # Hardcoded to match pyproject.toml
 USER_AGENT = f"KimiCLI/{VERSION}"


### PR DESCRIPTION
## Description
Fixes #2

### Problem
The v1.12.0 release binary reports version 1.9.0 because `importlib.metadata.version()` returns stale cached metadata from the initial package installation.

### Solution
Hardcode VERSION to "1.14.0" to match pyproject.toml.

### Changes
- Changed `VERSION = importlib.metadata.version("kimi-cli")` to `VERSION = "1.14.0"`

### Testing
- Verified version displays correctly
- No breaking changes